### PR TITLE
Bugfix: Replace fetchPriority `medium` by `auto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can load the library directly from unpkg or jsDelivr without installing:
 | `crossOrigin`      | `'anonymous' \| 'use-credentials'` | *none*                        | Sets `img.crossOrigin` on the icon image                               |
 | `imageType`        | `'image/png' \| 'image/jpeg'`      | `'image/png'`                 | Output format                                                          |
 | `quality`          | `number (0–1)`                     | `1`                           | JPEG quality (if `imageType === 'image/jpeg'`)                         |
-| `fetchPriority`    | `'low' \| 'medium' \| 'high'`      | `'high'`                      | Sets `img.fetchPriority`                                               |
+| `fetchPriority`    | `'low' \| 'high' \| 'auto'`        | `'high'`                      | Sets `img.fetchPriority`                                               |
 | `cleanup`          | `boolean`                          | `true`                        | Remove previously generated `<link>` tags before injecting new ones    |
 | `customAttribute`  | `string`                           | `'data-pwa-splash-generated'` | Attribute to flag generated tags                                       |
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,7 +4,7 @@ export function isIOS(): boolean {
     return /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window);
 }
 
-export function loadImage(url: string, crossOrigin?: 'anonymous' | 'use-credentials', fetchPriority?: 'low' | 'medium' | 'high'): Promise<HTMLImageElement> {
+export function loadImage(url: string, crossOrigin?: 'anonymous' | 'use-credentials', fetchPriority?: 'low' | 'high' | 'auto'): Promise<HTMLImageElement> {
     return new Promise((resolve, reject) => {
         const img = new Image();
         if (crossOrigin) img.crossOrigin = crossOrigin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,11 +49,12 @@ export interface PwaSplashOptions {
      */
     quality?: number;
     /**
-     * Fetch priority for the icon images. Can be 'low', 'medium', or 'high'.
+     * Fetch priority for the icon images. Can be 'low', 'high' or 'auto'.
      * This is used to optimize loading performance.
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority
      * @default 'high'
      */
-    fetchPriority?: 'low' | 'medium' | 'high';
+    fetchPriority?: 'low' | 'high' | 'auto';
     /**
      * If true, removes any previously generated splash screen link tags before adding new ones.
      * @default true


### PR DESCRIPTION
Because attribute doesn't accept a `medium` value.

However I'm not sure if there should be an option to set `auto` as it has same effect as not setting any fetch priority at all.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority